### PR TITLE
Add setting options on the naming format and location of the newly created diagrams

### DIFF
--- a/src/diagrams-view.tsx
+++ b/src/diagrams-view.tsx
@@ -1,4 +1,4 @@
-import { ItemView, WorkspaceLeaf, Workspace, View, Vault, TFile } from 'obsidian';
+import { ItemView, WorkspaceLeaf, Workspace, View, Vault, TFile, MarkdownView } from 'obsidian';
 import { DIAGRAM_VIEW_TYPE } from './constants';
 import { DiagramsApp } from './DiagramsApp';
 import * as React from "react";
@@ -52,8 +52,8 @@ export default class DiagramsView extends ItemView {
                 close()
             }
             else {
-                saveData(msg)
-                insertDiagram()
+                const { svgFile } = await saveData(msg)
+                insertDiagram(svgFile)
                 close()
             }
         }
@@ -62,33 +62,52 @@ export default class DiagramsView extends ItemView {
             this.workspace.detachLeavesOfType(DIAGRAM_VIEW_TYPE);
         }
 
-        const saveData = (msg: any) => {
+        const saveData = async (msg: any) => {
             const svgData = msg.svgMsg.data
             const svgBuffer = Buffer.from(svgData.replace('data:image/svg+xml;base64,', ''), 'base64')
+            let svgFile: TFile;
+            let xmlFile: TFile;
             if (this.diagramExists) {
-                const svgFile = this.vault.getAbstractFileByPath(this.svgPath)
-                const xmlFile = this.vault.getAbstractFileByPath(this.xmlPath)
+                svgFile = this.vault.getAbstractFileByPath(this.svgPath) as TFile
+                xmlFile = this.vault.getAbstractFileByPath(this.xmlPath) as TFile
                 if (!(svgFile instanceof TFile && xmlFile instanceof TFile)) {
                     return
                 }
                 this.vault.modifyBinary(svgFile, svgBuffer)
                 this.vault.modify(xmlFile, msg.svgMsg.xml)
+
             }
             else {
-                this.vault.createBinary(this.svgPath, svgBuffer)
-                this.vault.create(this.xmlPath, msg.svgMsg.xml)
+                svgFile = await this.vault.createBinary(this.svgPath, svgBuffer)
+                xmlFile = await this.vault.create(this.xmlPath, msg.svgMsg.xml)
+
             }
+
+            // Return the TFile objects for later usage.
+			// At this point the only use case is that `insertDiagram` needs the
+			// newly created xml TFile object. But just to make the interface
+			// clean, we return both files here, and regardless of newly created
+			// or not.
+            return {
+                svgFile,
+                xmlFile
+            };
         }
 
         const refreshMarkdownViews = async () => {
             // Haven't found a way to refresh the hostView.
         }
 
-        const insertDiagram = () => {
+        const insertDiagram = (svgFile: TFile) => {
+            // @ts-ignore: Type not documented.
+            const activeFilePath = this.workspace.getActiveViewOfType(MarkdownView).file;
+			// Build link text from the svg file to source markdown file.
+            const linkText = this.app.metadataCache.fileToLinktext(svgFile as TFile, activeFilePath.path);
+
             // @ts-ignore: Type not documented.
             const cursor = this.hostView.editor.getCursor();
             // @ts-ignore: Type not documented.
-            this.hostView.editor.replaceRange(`![[${this.svgPath}]]`, cursor);
+            this.hostView.editor.replaceRange(`![[${linkText}]]`, cursor);
 
         }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -109,9 +109,9 @@ export default class DiagramsNet extends Plugin {
 		const {activeFolder, activeFileBase} = this.getActiveFolderAndFileName();
 
 		const base = this.settings.nameWithFileNameAndTimestamp
-			? `${activeFileBase}-${moment().format().replaceAll(':', '.')}.svg`
+			? `${activeFileBase}-${moment().format().replaceAll(':', '.')}`
 			// @ts-ignore: Type not documented.
-			: await this.vault.getAvailablePathForAttachments('Diagram', 'svg');
+			: 'Diagram';
 
 		if (this.settings.createUnderVaultAttachmentsFolder) {
 
@@ -125,15 +125,21 @@ export default class DiagramsNet extends Plugin {
 					? attachmentFolder
 					: attachmentFolder + '/'}${base}`;
 
+			// @ts-ignore: Type not documented.
+			const availPath = await this.vault.getAvailablePathForAttachments(fullPath, 'svg');
+
 			return {
-				svgPath: fullPath,
-				xmlPath: this.getXmlPath(fullPath)
+				svgPath: availPath,
+				xmlPath: this.getXmlPath(availPath)
 			}
 		}
 
+		// @ts-ignore: Type not documented.
+		const availPath = await this.vault.getAvailablePathForAttachments(base, 'svg');
 		return {
-			svgPath: base,
-			xmlPath: this.getXmlPath(base)
+			// @ts-ignore: Type not documented.
+			svgPath: availPath,
+			xmlPath: this.getXmlPath(availPath)
 		}
 	}
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,66 @@
+import type DiagramsNet from "./main";
+
+import { App, PluginSettingTab, Setting } from "obsidian";
+
+export type Settings = {
+
+	// If true, we put the newly created diagram under the attachment folder
+	// specified in the vault's settings.
+	createUnderVaultAttachmentsFolder: boolean;
+
+	// If true, the newly created diagram will have filename in format of
+	// ${activeFileName}-${timestamp}.
+	nameWithFileNameAndTimestamp: boolean;
+
+};
+
+export const DEFAULT_SETTINGS: Settings = {
+	createUnderVaultAttachmentsFolder: false,
+	nameWithFileNameAndTimestamp: false,
+};
+
+export class DiagramsNetSettingsTab extends PluginSettingTab {
+
+	plugin: DiagramsNet;
+
+	constructor(app: App, plugin: DiagramsNet) {
+		super(app, plugin);
+		this.plugin = plugin;
+	}
+
+	display(): void {
+		const { containerEl } = this;
+
+		containerEl.empty();
+
+		new Setting(containerEl)
+			.setName('Create under the attachments folder')
+			.setDesc(
+				'Create new diagrams under the attachment folder defined in ' + 
+				"Obsidian's settings."
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.createUnderVaultAttachmentsFolder)
+					.onChange(async (value) => {
+						this.plugin.settings.createUnderVaultAttachmentsFolder = value;
+						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(containerEl)
+			.setName('Name with file name and timestamp')
+			.setDesc(
+				'If true, newly created embedded diagrams will have name in ' + 
+				'format of ${activeFileName}-${timestamp}.'
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.nameWithFileNameAndTimestamp)
+					.onChange(async (value) => {
+						this.plugin.settings.nameWithFileNameAndTimestamp = value;
+						await this.plugin.saveSettings();
+					})
+			);
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
       "DOM",
       "ES5",
       "ES6",
-      "ES7"
+      "ES7",
+      "ES2021.String"
     ]
   },
   "include": [


### PR DESCRIPTION
Hi, thank you for making this great plug-in!

This PR basically provides setting options and implementations of:

1. Allow creating diagrams in the attachment folder specified in the Obsidian Settings (Files & Links > Default location for new attachments).
2. Allow naming new diagrams in the format of `${activeFileName}-${timestamp}.svg`.

## Demos & Tests

### Testing Directory Structure

```
- Vault
    - testfolder
        - testfolder.md
    - ZOB_assets
```

### Settings page
<img width="842" alt="Screen Shot 2023-04-09 at 23 08 37" src="https://user-images.githubusercontent.com/11176415/230839287-b82e2d53-a242-43b5-95b0-e273b43d08d3.png">

### Default location: "Same folder as current file", timestamp naming on, wikilink: relative path

**Obsidian settings**

![Screen Shot 2023-04-09 at 23 19 48](https://user-images.githubusercontent.com/11176415/230839660-9d8459c8-07f1-44fd-82d8-9aa6244b6e8b.png)


**Demo**

https://user-images.githubusercontent.com/11176415/230839195-d1f35ce7-2977-49ab-8e87-45136f72e5e6.mov

**In File Explorer**

![Screen Shot 2023-04-09 at 23 10 13](https://user-images.githubusercontent.com/11176415/230839787-49eef2ba-2703-4209-b50d-c3a55c4583c1.png)

### Default location: specified global attachments folder, wikilink: relative path

![Screen Shot 2023-04-09 at 23 12 04](https://user-images.githubusercontent.com/11176415/230840053-c36e5060-c9e7-4d65-a294-ec98caabb5df.png)

![Screen Shot 2023-04-09 at 23 12 22](https://user-images.githubusercontent.com/11176415/230840084-b74879a1-d6c8-406b-803c-fef7236212b5.png)

### Default location: specified global attachments folder, wikilink: absolute path

![Screen Shot 2023-04-09 at 23 12 04](https://user-images.githubusercontent.com/11176415/230840053-c36e5060-c9e7-4d65-a294-ec98caabb5df.png)

![Screen Shot 2023-04-09 at 23 13 09](https://user-images.githubusercontent.com/11176415/230840479-fb1f8fb3-7e96-4be0-9550-d68afbbc0b7f.png)

