### PR TITLE
Fix diagram creation path and add setting option for naming the diagram as <current-file>-<timestamp>

### DIFF
--- a/src/diagrams-view.tsx
+++ b/src/diagrams-view.tsx
@@ -5,128 +5,128 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 
 export default class DiagramsView extends ItemView {
-    filePath: string;
-    fileName: string;
-    svgPath: string;
-    xmlPath: string;
-    diagramExists: boolean;
-    hostView: View;
-    vault: Vault;
-    workspace: Workspace;
-    displayText: string;
+	filePath: string;
+	fileName: string;
+	svgPath: string;
+	xmlPath: string;
+	diagramExists: boolean;
+	hostView: View;
+	vault: Vault;
+	workspace: Workspace;
+	displayText: string;
 
-    getDisplayText(): string {
-        return this.displayText ?? 'Diagram';
-    }
+	getDisplayText(): string {
+		return this.displayText ?? 'Diagram';
+	}
 
-    getViewType(): string {
-        return DIAGRAM_VIEW_TYPE;
-    }
+	getViewType(): string {
+		return DIAGRAM_VIEW_TYPE;
+	}
 
-    constructor(leaf: WorkspaceLeaf, hostView: View,
-        initialFileInfo: { path: string, basename: string, svgPath: string, xmlPath: string, diagramExists: boolean }) {
-        super(leaf);
-        this.filePath = initialFileInfo.path;
-        this.fileName = initialFileInfo.basename;
-        this.svgPath = initialFileInfo.svgPath;
-        this.xmlPath = initialFileInfo.xmlPath;
-        this.diagramExists = initialFileInfo.diagramExists;
-        this.vault = this.app.vault;
-        this.workspace = this.app.workspace;
-        this.hostView = hostView
-    }
-
-
+	constructor(leaf: WorkspaceLeaf, hostView: View,
+		initialFileInfo: { path: string, basename: string, svgPath: string, xmlPath: string, diagramExists: boolean }) {
+		super(leaf);
+		this.filePath = initialFileInfo.path;
+		this.fileName = initialFileInfo.basename;
+		this.svgPath = initialFileInfo.svgPath;
+		this.xmlPath = initialFileInfo.xmlPath;
+		this.diagramExists = initialFileInfo.diagramExists;
+		this.vault = this.app.vault;
+		this.workspace = this.app.workspace;
+		this.hostView = hostView
+	}
 
 
-    async onOpen() {
 
-        const handleExit = async () => {
-            close()
-        }
 
-        const handleSaveAndExit = async (msg: any) => {
-            if (this.diagramExists) {
-                saveData(msg)
-                refreshMarkdownViews()
-                close()
-            }
-            else {
-                const { svgFile } = await saveData(msg)
-                insertDiagram(svgFile)
-                close()
-            }
-        }
+	async onOpen() {
 
-        const close = () => {
-            this.workspace.detachLeavesOfType(DIAGRAM_VIEW_TYPE);
-        }
+		const handleExit = async () => {
+			close()
+		}
 
-        const saveData = async (msg: any) => {
-            const svgData = msg.svgMsg.data
-            const svgBuffer = Buffer.from(svgData.replace('data:image/svg+xml;base64,', ''), 'base64')
+		const handleSaveAndExit = async (msg: any) => {
+			if (this.diagramExists) {
+				saveData(msg)
+				refreshMarkdownViews()
+				close()
+			}
+			else {
+				const { svgFile } = await saveData(msg)
+				insertDiagram(svgFile)
+				close()
+			}
+		}
 
-            let svgFile: TFile;
-            let xmlFile: TFile;
-            if (this.diagramExists) {
-                svgFile = this.vault.getAbstractFileByPath(this.svgPath) as TFile
-                xmlFile = this.vault.getAbstractFileByPath(this.xmlPath) as TFile
-                if (!(svgFile instanceof TFile && xmlFile instanceof TFile)) {
-                    return
-                }
-                this.vault.modifyBinary(svgFile, svgBuffer)
-                this.vault.modify(xmlFile, msg.svgMsg.xml)
-            }
-            else {
-                svgFile = await this.vault.createBinary(this.svgPath, svgBuffer)
-                xmlFile = await this.vault.create(this.xmlPath, msg.svgMsg.xml)
+		const close = () => {
+			this.workspace.detachLeavesOfType(DIAGRAM_VIEW_TYPE);
+		}
 
-            }
+		const saveData = async (msg: any) => {
+			const svgData = msg.svgMsg.data
+			const svgBuffer = Buffer.from(svgData.replace('data:image/svg+xml;base64,', ''), 'base64')
 
-            // Return the TFile objects for later usage.
+			let svgFile: TFile;
+			let xmlFile: TFile;
+			if (this.diagramExists) {
+				svgFile = this.vault.getAbstractFileByPath(this.svgPath) as TFile
+				xmlFile = this.vault.getAbstractFileByPath(this.xmlPath) as TFile
+				if (!(svgFile instanceof TFile && xmlFile instanceof TFile)) {
+					return
+				}
+				this.vault.modifyBinary(svgFile, svgBuffer)
+				this.vault.modify(xmlFile, msg.svgMsg.xml)
+			}
+			else {
+				svgFile = await this.vault.createBinary(this.svgPath, svgBuffer)
+				xmlFile = await this.vault.create(this.xmlPath, msg.svgMsg.xml)
+
+			}
+
+			// Return the TFile objects for later usage.
 			// At this point the only use case is that `insertDiagram` needs the
 			// newly created xml TFile object. But just to make the interface
 			// clean, we return both files here, and regardless of newly created
 			// or not.
-            return {
-                svgFile,
-                xmlFile
-            };
-        }
+			return {
+				svgFile,
+				xmlFile
+			};
+		}
 
-        const refreshMarkdownViews = async () => {
-            // Haven't found a way to refresh the hostView.
-        }
+		const refreshMarkdownViews = async () => {
+			// Haven't found a way to refresh the hostView.
+		}
 
-        const insertDiagram = (svgFile: TFile) => {
+		const insertDiagram = (svgFile: TFile) => {
 			// If active file is null, we are at the root folder.
 			const activeFilePath = this.workspace.getActiveFile()?.path ?? '';
 			// Build link text from the svg file to source markdown file.
-            const linkText = this.app.metadataCache.fileToLinktext(svgFile, activeFilePath);
+			const linkText = this.app.metadataCache.fileToLinktext(svgFile, activeFilePath);
 
-            // @ts-ignore: Type not documented.
-            const cursor = this.hostView.editor.getCursor();
-            // @ts-ignore: Type not documented.
-            this.hostView.editor.replaceRange(`![[${linkText}]]`, cursor);
+			// @ts-ignore: Type not documented.
+			const cursor = this.hostView.editor.getCursor();
+			// @ts-ignore: Type not documented.
+			this.hostView.editor.replaceRange(`![[${linkText}]]`, cursor);
 
-        }
+		}
 
-        const container = this.containerEl.children[1];
+		const container = this.containerEl.children[1];
 
-        ReactDOM.render(
-            <DiagramsApp
-                xmlPath={this.xmlPath}
-                diagramExists={this.diagramExists}
-                vault={this.vault}
-                handleExit={handleExit}
-                handleSaveAndExit={handleSaveAndExit}
-            />,
-            container
-        );
-    }
+		ReactDOM.render(
+			<DiagramsApp
+				xmlPath={this.xmlPath}
+				diagramExists={this.diagramExists}
+				vault={this.vault}
+				handleExit={handleExit}
+				handleSaveAndExit={handleSaveAndExit}
+			/>,
+			container
+		);
+	}
 
-    async onClose() {
-        ReactDOM.unmountComponentAtNode(this.containerEl.children[1]);
-    }
+	async onClose() {
+		ReactDOM.unmountComponentAtNode(this.containerEl.children[1]);
+	}
 
 }

--- a/src/diagrams-view.tsx
+++ b/src/diagrams-view.tsx
@@ -24,7 +24,7 @@ export default class DiagramsView extends ItemView {
     }
 
     constructor(leaf: WorkspaceLeaf, hostView: View,
-        initialFileInfo: { path: string, basename: string, svgPath: string, xmlPath: string, diagramExists: boolean } ) {
+        initialFileInfo: { path: string, basename: string, svgPath: string, xmlPath: string, diagramExists: boolean }) {
         super(leaf);
         this.filePath = initialFileInfo.path;
         this.fileName = initialFileInfo.basename;

--- a/src/diagrams-view.tsx
+++ b/src/diagrams-view.tsx
@@ -5,128 +5,128 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 
 export default class DiagramsView extends ItemView {
-	filePath: string;
-	fileName: string;
-	svgPath: string;
-	xmlPath: string;
-	diagramExists: boolean;
-	hostView: View;
-	vault: Vault;
-	workspace: Workspace;
-	displayText: string;
+    filePath: string;
+    fileName: string;
+    svgPath: string;
+    xmlPath: string;
+    diagramExists: boolean;
+    hostView: View;
+    vault: Vault;
+    workspace: Workspace;
+    displayText: string;
 
-	getDisplayText(): string {
-		return this.displayText ?? 'Diagram';
-	}
+    getDisplayText(): string {
+        return this.displayText ?? 'Diagram';
+    }
 
-	getViewType(): string {
-		return DIAGRAM_VIEW_TYPE;
-	}
+    getViewType(): string {
+        return DIAGRAM_VIEW_TYPE;
+    }
 
-	constructor(leaf: WorkspaceLeaf, hostView: View,
-		initialFileInfo: { path: string, basename: string, svgPath: string, xmlPath: string, diagramExists: boolean }) {
-		super(leaf);
-		this.filePath = initialFileInfo.path;
-		this.fileName = initialFileInfo.basename;
-		this.svgPath = initialFileInfo.svgPath;
-		this.xmlPath = initialFileInfo.xmlPath;
-		this.diagramExists = initialFileInfo.diagramExists;
-		this.vault = this.app.vault;
-		this.workspace = this.app.workspace;
-		this.hostView = hostView
-	}
-
-
+    constructor(leaf: WorkspaceLeaf, hostView: View,
+        initialFileInfo: { path: string, basename: string, svgPath: string, xmlPath: string, diagramExists: boolean } ) {
+        super(leaf);
+        this.filePath = initialFileInfo.path;
+        this.fileName = initialFileInfo.basename;
+        this.svgPath = initialFileInfo.svgPath;
+        this.xmlPath = initialFileInfo.xmlPath;
+        this.diagramExists = initialFileInfo.diagramExists;
+        this.vault = this.app.vault;
+        this.workspace = this.app.workspace;
+        this.hostView = hostView
+    }
 
 
-	async onOpen() {
 
-		const handleExit = async () => {
-			close()
-		}
 
-		const handleSaveAndExit = async (msg: any) => {
-			if (this.diagramExists) {
-				saveData(msg)
-				refreshMarkdownViews()
-				close()
-			}
-			else {
-				const { svgFile } = await saveData(msg)
-				insertDiagram(svgFile)
-				close()
-			}
-		}
+    async onOpen() {
 
-		const close = () => {
-			this.workspace.detachLeavesOfType(DIAGRAM_VIEW_TYPE);
-		}
+        const handleExit = async () => {
+            close()
+        }
 
-		const saveData = async (msg: any) => {
-			const svgData = msg.svgMsg.data
-			const svgBuffer = Buffer.from(svgData.replace('data:image/svg+xml;base64,', ''), 'base64')
+        const handleSaveAndExit = async (msg: any) => {
+            if (this.diagramExists) {
+                saveData(msg)
+                refreshMarkdownViews()
+                close()
+            }
+            else {
+                const { svgFile } = await saveData(msg)
+                insertDiagram(svgFile)
+                close()
+            }
+        }
 
-			let svgFile: TFile;
-			let xmlFile: TFile;
-			if (this.diagramExists) {
-				svgFile = this.vault.getAbstractFileByPath(this.svgPath) as TFile
-				xmlFile = this.vault.getAbstractFileByPath(this.xmlPath) as TFile
-				if (!(svgFile instanceof TFile && xmlFile instanceof TFile)) {
-					return
-				}
-				this.vault.modifyBinary(svgFile, svgBuffer)
-				this.vault.modify(xmlFile, msg.svgMsg.xml)
-			}
-			else {
-				svgFile = await this.vault.createBinary(this.svgPath, svgBuffer)
-				xmlFile = await this.vault.create(this.xmlPath, msg.svgMsg.xml)
+        const close = () => {
+            this.workspace.detachLeavesOfType(DIAGRAM_VIEW_TYPE);
+        }
 
-			}
+        const saveData = async (msg: any) => {
+            const svgData = msg.svgMsg.data
+            const svgBuffer = Buffer.from(svgData.replace('data:image/svg+xml;base64,', ''), 'base64')
 
-			// Return the TFile objects for later usage.
-			// At this point the only use case is that `insertDiagram` needs the
-			// newly created xml TFile object. But just to make the interface
-			// clean, we return both files here, and regardless of newly created
-			// or not.
-			return {
-				svgFile,
-				xmlFile
-			};
-		}
+            let svgFile: TFile;
+            let xmlFile: TFile;
+            if (this.diagramExists) {
+                svgFile = this.vault.getAbstractFileByPath(this.svgPath) as TFile
+                xmlFile = this.vault.getAbstractFileByPath(this.xmlPath) as TFile
+                if (!(svgFile instanceof TFile && xmlFile instanceof TFile)) {
+                    return
+                }
+                this.vault.modifyBinary(svgFile, svgBuffer)
+                this.vault.modify(xmlFile, msg.svgMsg.xml)
+            }
+            else {
+                svgFile = await this.vault.createBinary(this.svgPath, svgBuffer)
+                xmlFile = await this.vault.create(this.xmlPath, msg.svgMsg.xml)
 
-		const refreshMarkdownViews = async () => {
-			// Haven't found a way to refresh the hostView.
-		}
+            }
 
-		const insertDiagram = (svgFile: TFile) => {
-			// If active file is null, we are at the root folder.
-			const activeFilePath = this.workspace.getActiveFile()?.path ?? '';
-			// Build link text from the svg file to source markdown file.
-			const linkText = this.app.metadataCache.fileToLinktext(svgFile, activeFilePath);
+            // Return the TFile objects for later usage.
+            // At this point the only use case is that `insertDiagram` needs the
+            // newly created xml TFile object. But just to make the interface
+            // clean, we return both files here, and regardless of newly created
+            // or not.
+            return {
+                svgFile,
+                xmlFile
+            };
+        }
 
-			// @ts-ignore: Type not documented.
-			const cursor = this.hostView.editor.getCursor();
-			// @ts-ignore: Type not documented.
-			this.hostView.editor.replaceRange(`![[${linkText}]]`, cursor);
+        const refreshMarkdownViews = async () => {
+            // Haven't found a way to refresh the hostView.
+        }
 
-		}
+        const insertDiagram = (svgFile: TFile) => {
+            // If active file is null, we are at the root folder.
+            const activeFilePath = this.workspace.getActiveFile()?.path ?? '';
+            // Build link text from the svg file to source markdown file.
+            const linkText = this.app.metadataCache.fileToLinktext(svgFile, activeFilePath);
 
-		const container = this.containerEl.children[1];
+            // @ts-ignore: Type not documented.
+            const cursor = this.hostView.editor.getCursor();
+            // @ts-ignore: Type not documented.
+            this.hostView.editor.replaceRange(`![[${linkText}]]`, cursor);
 
-		ReactDOM.render(
-			<DiagramsApp
-				xmlPath={this.xmlPath}
-				diagramExists={this.diagramExists}
-				vault={this.vault}
-				handleExit={handleExit}
-				handleSaveAndExit={handleSaveAndExit}
-			/>,
-			container
-		);
-	}
+        }
 
-	async onClose() {
-		ReactDOM.unmountComponentAtNode(this.containerEl.children[1]);
-	}
+        const container = this.containerEl.children[1];
+
+        ReactDOM.render(
+            <DiagramsApp
+                xmlPath={this.xmlPath}
+                diagramExists={this.diagramExists}
+                vault={this.vault}
+                handleExit={handleExit}
+                handleSaveAndExit={handleSaveAndExit}
+            />,
+            container
+        );
+    }
+
+    async onClose() {
+        ReactDOM.unmountComponentAtNode(this.containerEl.children[1]);
+    }
 
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,46 @@
+import type DiagramsNet from "./main";
+
+import { App, PluginSettingTab, Setting } from "obsidian";
+
+export type Settings = {
+
+	// If true, the newly created diagram will have filename in format of
+	// ${activeFileName}-${timestamp}.
+	nameWithFileNameAndTimestamp: boolean;
+
+};
+
+export const DEFAULT_SETTINGS: Settings = {
+	nameWithFileNameAndTimestamp: false,
+};
+
+export class DiagramsNetSettingsTab extends PluginSettingTab {
+
+	plugin: DiagramsNet;
+
+	constructor(app: App, plugin: DiagramsNet) {
+		super(app, plugin);
+		this.plugin = plugin;
+	}
+
+	display(): void {
+		const { containerEl } = this;
+
+		containerEl.empty();
+
+		new Setting(containerEl)
+			.setName('Name with file name and timestamp')
+			.setDesc(
+				'If true, newly created embedded diagrams will have name in ' + 
+				'format of ${activeFileName}-${timestamp}.'
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.nameWithFileNameAndTimestamp)
+					.onChange(async (value) => {
+						this.plugin.settings.nameWithFileNameAndTimestamp = value;
+						await this.plugin.saveSettings();
+					})
+			);
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
       "DOM",
       "ES5",
       "ES6",
-      "ES7"
+      "ES7",
+			"ES2021.String"
     ]
   },
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
       "ES5",
       "ES6",
       "ES7",
-			"ES2021.String"
+      "ES2021.String"
     ]
   },
   "include": [


### PR DESCRIPTION
This PR does the following things:
1. Fix the file creation path bug: when the Obsidian's attachment folder setting is "Same folder as current file", the new diagram will actually be created in the root vault folder. The reason is that `vault.getAvailablePathForAttachments` needs the active file (or null if no file has been opened yet) as its third argument to prepend the correct folder. 
2. Add a setting option to allow naming the newly created diagram in the format of `${currentFileName}-${timestamp}`, which is a popular way of naming for attachments associated to a note.

## Tests

**Settings Page**

![Screen Shot 2023-04-11 at 10 00 51](https://user-images.githubusercontent.com/11176415/231243200-0291e6bb-58ba-45f8-9079-d1e8f33133d3.png)

**Same folder as current file - default naming**

https://user-images.githubusercontent.com/11176415/231243398-6941d20f-3859-4a05-84fe-f127d676e3ba.mov

**Same folder as current file - timestamp naming**

https://user-images.githubusercontent.com/11176415/231243487-90fc5f27-7be1-40f9-9285-5b8fdaf28562.mov

**Resulting files**
\* I'm using folder notes so technically the active file is `testfolder/testfolder.md`.

![Screen Shot 2023-04-11 at 10 00 34](https://user-images.githubusercontent.com/11176415/231243673-d4d10306-b46d-4eb8-9752-baa9126d7cfb.png)
