### PR TITLE
Modal / RefreshDiagramm / Attachmentpath

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-	"id": "obsidian-diagrams-net",
-	"name": "Diagrams.net",
+	"id": "obsidian-diagrams-net-test",
+	"name": "Diagrams.net (Stieber)",
 	"version": "1.0.4",
 	"minAppVersion": "0.12.0",
 	"description": "Enable diagrams.net (previously draw.io) type diagrams, with the diagrams.net embedded editor.",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-	"id": "obsidian-diagrams-net-test",
-	"name": "Diagrams.net (Stieber)",
+	"id": "obsidian-diagrams-net",
+	"name": "Diagrams.net",
 	"version": "1.0.4",
 	"minAppVersion": "0.12.0",
 	"description": "Enable diagrams.net (previously draw.io) type diagrams, with the diagrams.net embedded editor.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
 	"name": "obsidian-diagrams-net",
-	"version": "1.0.1",
+	"version": "1.0.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-diagrams-net",
-			"version": "1.0.1",
+			"version": "1.0.4",
 			"license": "MIT",
 			"dependencies": {
-				"bops": "^1.0.1",
 				"react": "17.0",
 				"react-dom": "17.0"
 			},
@@ -463,23 +462,6 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
 			"peer": true
-		},
-		"node_modules/base64-js": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.0.2.tgz",
-			"integrity": "sha512-ZXBDPMt/v/8fsIqn+Z5VwrhdR6jVka0bYobHdGia0Nxi7BJ9i/Uvml3AocHIBtIIBhZjBw5MR0aR4ROs/8+SNg==",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/bops": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/bops/-/bops-1.0.1.tgz",
-			"integrity": "sha512-qCMBuZKP36tELrrgXpAfM+gHzqa0nLsWZ+L37ncsb8txYlnAoxOPpVp+g7fK0sGkMXfA0wl8uQkESqw3v4HNag==",
-			"dependencies": {
-				"base64-js": "1.0.2",
-				"to-utf8": "0.0.1"
-			}
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
@@ -1889,11 +1871,6 @@
 				"node": ">=8.0"
 			}
 		},
-		"node_modules/to-utf8": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
-			"integrity": "sha512-zks18/TWT1iHO3v0vFp5qLKOG27m67ycq/Y7a7cTiRuUNlc4gf3HGnkRgMv0NyhnfTamtkYBJl+YeD1/j07gBQ=="
-		},
 		"node_modules/tslib": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -2334,20 +2311,6 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
 			"peer": true
-		},
-		"base64-js": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.0.2.tgz",
-			"integrity": "sha512-ZXBDPMt/v/8fsIqn+Z5VwrhdR6jVka0bYobHdGia0Nxi7BJ9i/Uvml3AocHIBtIIBhZjBw5MR0aR4ROs/8+SNg=="
-		},
-		"bops": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/bops/-/bops-1.0.1.tgz",
-			"integrity": "sha512-qCMBuZKP36tELrrgXpAfM+gHzqa0nLsWZ+L37ncsb8txYlnAoxOPpVp+g7fK0sGkMXfA0wl8uQkESqw3v4HNag==",
-			"requires": {
-				"base64-js": "1.0.2",
-				"to-utf8": "0.0.1"
-			}
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -3361,11 +3324,6 @@
 			"requires": {
 				"is-number": "^7.0.0"
 			}
-		},
-		"to-utf8": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
-			"integrity": "sha512-zks18/TWT1iHO3v0vFp5qLKOG27m67ycq/Y7a7cTiRuUNlc4gf3HGnkRgMv0NyhnfTamtkYBJl+YeD1/j07gBQ=="
 		},
 		"tslib": {
 			"version": "2.3.1",

--- a/src/DiagramsApp.tsx
+++ b/src/DiagramsApp.tsx
@@ -42,6 +42,6 @@ export const DiagramsApp = (props: any) => {
         }
     }, [xmlData])
 
-    return <div id="drawIoDiagramFrame" />
+    return <div id="drawIoDiagramFrame" className="modal-content diagrams-modal" />;
 
 };

--- a/src/diagrams-view.tsx
+++ b/src/diagrams-view.tsx
@@ -1,10 +1,10 @@
-import { ItemView, WorkspaceLeaf, Workspace, View, Vault, TFile } from 'obsidian';
-import { DIAGRAM_VIEW_TYPE } from './constants';
-import { DiagramsApp } from './DiagramsApp';
+import { App, Modal, TFile, Vault, View, Workspace } from 'obsidian';
 import * as React from "react";
 import * as ReactDOM from "react-dom";
+import { DIAGRAM_VIEW_TYPE } from './constants';
+import { DiagramsApp } from './DiagramsApp';
 
-export default class DiagramsView extends ItemView {
+export default class DiagramsView extends Modal {
     filePath: string;
     fileName: string;
     svgPath: string;
@@ -23,9 +23,9 @@ export default class DiagramsView extends ItemView {
         return DIAGRAM_VIEW_TYPE;
     }
 
-    constructor(leaf: WorkspaceLeaf, hostView: View,
+    constructor(app: App, hostView: View,
         initialFileInfo: { path: string, basename: string, svgPath: string, xmlPath: string, diagramExists: boolean }) {
-        super(leaf);
+        super(app);
         this.filePath = initialFileInfo.path;
         this.fileName = initialFileInfo.basename;
         this.svgPath = initialFileInfo.svgPath;
@@ -60,6 +60,7 @@ export default class DiagramsView extends ItemView {
 
         const close = () => {
             this.workspace.detachLeavesOfType(DIAGRAM_VIEW_TYPE);
+            this.close();
         }
 
         const saveData = (msg: any) => {
@@ -93,6 +94,8 @@ export default class DiagramsView extends ItemView {
         }
 
         const container = this.containerEl.children[1];
+        container.setAttr("style", "width: 100vw; height: 100vh;");
+
 
         ReactDOM.render(
             <DiagramsApp

--- a/src/diagrams-view.tsx
+++ b/src/diagrams-view.tsx
@@ -1,4 +1,4 @@
-import { App, Modal, TFile, Vault, View, Workspace } from 'obsidian';
+import { App, MarkdownView, Modal, TFile, Vault, View, Workspace } from 'obsidian';
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { DIAGRAM_VIEW_TYPE } from './constants';
@@ -83,6 +83,18 @@ export default class DiagramsView extends Modal {
 
         const refreshMarkdownViews = async () => {
             // Haven't found a way to refresh the hostView.
+            // Delete the preceding image link through regular matching! and add it back in the modified content
+            const editor = this.app.workspace.getActiveViewOfType(MarkdownView).editor;
+            const cursor = editor.getCursor();
+            const line = editor.getLine(cursor.line);
+            const match = line.match(/\[\[.*?\]\]/);
+            if (!match) return;
+            const modifiedLine = line.replace(/\!\[\[/, '[[');
+            editor.replaceRange(modifiedLine, { line: cursor.line, ch: 0 }, { line: cursor.line, ch: line.length });
+            setTimeout(() => {
+              const finalLine = modifiedLine.replace(/\[\[/, '![[');
+              editor.replaceRange(finalLine, { line: cursor.line, ch: 0 }, { line: cursor.line, ch: modifiedLine.length });
+            }, 200);
         }
 
         const insertDiagram = () => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -74,7 +74,7 @@ export default class DiagramsNet extends Plugin {
 
 	async availablePath() {
 		// @ts-ignore: Type not documented.
-		const base = await this.vault.getAvailablePathForAttachments('Diagram', 'svg')
+		const base = await this.vault.getAvailablePathForAttachments('Diagram', 'svg', this.workspace.getActiveFile())
 		return {
 			svgPath: base,
 			xmlPath: this.getXmlPath(base)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,5 @@
-import { addIcon, Notice, Plugin, TFile, Vault, Workspace, WorkspaceLeaf, MenuItem, MarkdownView, TAbstractFile, Menu, Editor } from 'obsidian';
-import { DIAGRAM_VIEW_TYPE, ICON } from './constants';
+import { addIcon, Editor, MarkdownView, Menu, MenuItem, Notice, Plugin, TAbstractFile, TFile, Vault, Workspace } from 'obsidian';
+import { ICON } from './constants';
 import DiagramsView from './diagrams-view';
 
 
@@ -15,20 +15,6 @@ export default class DiagramsNet extends Plugin {
 		this.workspace = this.app.workspace;
 
 		addIcon("diagram", ICON);
-
-		this.registerView(
-			DIAGRAM_VIEW_TYPE,
-			(leaf: WorkspaceLeaf) => (
-				this.diagramsView = new DiagramsView(
-					leaf, null, {
-					path: this.activeLeafPath(this.workspace),
-					basename: this.activeLeafName(this.workspace),
-					svgPath: '',
-					xmlPath: '',
-					diagramExists: false,
-				})
-			)
-		);
 
 		this.addCommand({
 			id: 'app:diagrams-net-new-diagram',
@@ -126,17 +112,8 @@ export default class DiagramsNet extends Plugin {
 	}
 
 	async initView(fileInfo: any) {
-		if (this.app.workspace.getLeavesOfType(DIAGRAM_VIEW_TYPE).length > 0) {
-			return
-		}
 		const hostView = this.workspace.getActiveViewOfType(MarkdownView);
-
-		const leaf = this.app.workspace.splitActiveLeaf('horizontal')
-		// TODO: Replace splitActiveLeaf with getLeaf, when official version => 0.15.
-		// const leaf = this.app.workspace.getLeaf(true, 'horizontal')
-
-		const diagramView = new DiagramsView(leaf, hostView, fileInfo)
-		leaf.open(diagramView)
+		new DiagramsView(this.app, hostView, fileInfo).open();
 	}
 
 	handleDeleteFile(file: TAbstractFile) {

--- a/src/useDiagramsNet.jsx
+++ b/src/useDiagramsNet.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import ReactDOM from 'react-dom'
+import ReactDOM from 'react-dom';
 const bgColor="white"
 /**
  * - Based on: https://github.com/jgraph/drawio-integration
@@ -136,7 +136,6 @@ function useDiagramsNet(onSaveCallback, onStopEditing, getName, getData) {
             ref={frameRef}
             // sandbox="allow-scripts allow-same-origin"
             style={{
-                position: 'fixed',
                 width: '100%',
                 height: '100%',
                 left: '0',


### PR DESCRIPTION
Hi,

i refactored changes from https://github.com/jensmtg/obsidian-diagrams-net/pull/22 to match `obsidian:latest`

- Edit in Modal 
- Refresh diagram in document after edit

Added:
- fix: Create new Diagram will take the configured attachment path from obsidian settings